### PR TITLE
Convert Next.js config to ES module

### DIFF
--- a/web/frontend/next.config.js
+++ b/web/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- update the Next.js configuration to use an ES module default export so it matches the module type setting

## Testing
- not run (not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e305087d2c832c9d3f1831f886ec22