### PR TITLE
Add SQLite persistence to analysis repository

### DIFF
--- a/web/backend/app/main.py
+++ b/web/backend/app/main.py
@@ -1,0 +1,174 @@
+"""aiohttp application exposing admin analysis endpoints."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+from aiohttp import ContentTypeError, web
+import aiohttp_cors
+
+from app.api.admin import AdminService, AnalysisPayload, AnalysisItemPayload
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@web.middleware
+async def request_logging_middleware(
+    request: web.Request, handler: web.Handler
+) -> web.StreamResponse:
+    start_time = time.perf_counter()
+    try:
+        response = await handler(request)
+    except KeyError as exc:
+        message = exc.args[0] if exc.args else "Not found"
+        response = web.json_response({"error": str(message)}, status=404)
+    except web.HTTPException as exc:
+        if exc.status < 400:
+            raise
+        message = exc.text or exc.reason or "Bad Request"
+        response = web.json_response({"error": message}, status=exc.status, headers=exc.headers)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Unhandled server error")
+        response = web.json_response({"error": "Internal Server Error"}, status=500)
+    finally:
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        status = response.status if 'response' in locals() else "-"
+        logger.info("%s %s -> %s (%.2f ms)", request.method, request.path_qs, status, duration_ms)
+    return response
+
+
+def create_app() -> web.Application:
+    app = web.Application(middlewares=[request_logging_middleware])
+    app["admin_service"] = AdminService()
+
+    app.router.add_get("/admin/analysis", list_analysis)
+    app.router.add_post("/admin/analysis", create_analysis)
+    app.router.add_get("/health", health_check)
+
+    cors = aiohttp_cors.setup(
+        app,
+        defaults={
+            "http://localhost:3000": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                allow_headers=("Content-Type", "Accept"),
+                allow_methods=("GET", "POST", "OPTIONS"),
+            ),
+            "http://127.0.0.1:3000": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                allow_headers=("Content-Type", "Accept"),
+                allow_methods=("GET", "POST", "OPTIONS"),
+            ),
+        },
+    )
+
+    for route in list(app.router.routes()):
+        cors.add(route)
+
+    return app
+
+
+async def list_analysis(request: web.Request) -> web.Response:
+    service: AdminService = request.app["admin_service"]
+    snapshot_id_param = request.rel_url.query.get("snapshot_id")
+    snapshot_id = None
+    if snapshot_id_param is not None:
+        try:
+            snapshot_id = int(snapshot_id_param)
+        except (TypeError, ValueError):
+            raise web.HTTPBadRequest(text="snapshot_id must be an integer")
+
+    analysis = await service.list_analysis(snapshot_id=snapshot_id)
+    return web.json_response(analysis)
+
+
+async def create_analysis(request: web.Request) -> web.Response:
+    service: AdminService = request.app["admin_service"]
+
+    try:
+        data = await request.json()
+    except (json.JSONDecodeError, ContentTypeError):
+        raise web.HTTPBadRequest(text="Invalid JSON body")
+
+    if not isinstance(data, dict):
+        raise web.HTTPBadRequest(text="Request body must be a JSON object")
+
+    payload = _parse_analysis_payload(data)
+    record = await service.create_analysis(payload)
+    return web.json_response(record, status=201)
+
+
+def _parse_analysis_payload(data: dict[str, Any]) -> AnalysisPayload:
+    if "snapshot_id" not in data:
+        raise web.HTTPBadRequest(text="snapshot_id is required")
+    snapshot_id = _ensure_int(data.get("snapshot_id"), "snapshot_id")
+
+    author = data.get("author")
+    if not isinstance(author, str) or not author.strip():
+        raise web.HTTPBadRequest(text="author must be a non-empty string")
+
+    title = data.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise web.HTTPBadRequest(text="title must be a non-empty string")
+
+    notes = data.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        raise web.HTTPBadRequest(text="notes must be a string or null")
+
+    if "items" not in data:
+        raise web.HTTPBadRequest(text="items is required")
+    items = data.get("items")
+    if not isinstance(items, list):
+        raise web.HTTPBadRequest(text="items must be a list")
+
+    parsed_items: list[AnalysisItemPayload] = []
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise web.HTTPBadRequest(text=f"items[{index}] must be an object")
+
+        label = item.get("label")
+        if not isinstance(label, str) or not label.strip():
+            raise web.HTTPBadRequest(text=f"items[{index}].label must be a non-empty string")
+
+        score = _ensure_int(item.get("score"), f"items[{index}].score")
+
+        payload = item.get("payload")
+        if payload is not None and not isinstance(payload, dict):
+            raise web.HTTPBadRequest(text=f"items[{index}].payload must be an object or null")
+
+        parsed_items.append(
+            AnalysisItemPayload(label=label, score=score, payload=payload),
+        )
+
+    return AnalysisPayload(
+        snapshot_id=snapshot_id,
+        author=author.strip(),
+        title=title.strip(),
+        notes=notes.strip() if isinstance(notes, str) else notes,
+        items=parsed_items,
+    )
+
+
+def _ensure_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise web.HTTPBadRequest(text=f"{field_name} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise web.HTTPBadRequest(text=f"{field_name} must be an integer")
+
+
+async def health_check(_: web.Request) -> web.Response:
+    return web.json_response({"status": "ok"})
+
+
+if __name__ == "__main__":
+    web.run_app(create_app(), host="0.0.0.0", port=8000)

--- a/web/backend/app/services/repository.py
+++ b/web/backend/app/services/repository.py
@@ -1,21 +1,157 @@
-"""In-memory repository helpers for analysis persistence."""
+"""SQLite-backed repository helpers for analysis persistence."""
 from __future__ import annotations
 
 import asyncio
+import json
+import sqlite3
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+
+import aiosqlite
 
 from app.models.analysis_schema import AnalysisItemRecord, AnalysisRecord, build_analysis
 
 
 class AnalysisRepository:
-    """Store analysis records in memory with async-safe helpers."""
+    """Store analysis records using SQLite with async-safe helpers."""
 
-    def __init__(self) -> None:
+    def __init__(self, db_path: str = "data/cannahealth.db") -> None:
         self._lock = asyncio.Lock()
-        self._next_analysis_id = 1
-        self._next_item_id = 1
-        self._analysis: Dict[int, AnalysisRecord] = {}
+        self._init_lock = asyncio.Lock()
+        self._init_task: asyncio.Task[None] | None = None
+        self._db_path = db_path
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    async def _ensure_initialized(self) -> None:
+        async with self._init_lock:
+            if self._init_task is None:
+                self._init_task = asyncio.create_task(self._create_tables())
+            task = self._init_task
+        try:
+            await task
+        except Exception:
+            async with self._init_lock:
+                if self._init_task is task:
+                    self._init_task = None
+            raise
+
+    @asynccontextmanager
+    async def _connect(self) -> aiosqlite.Connection:
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA foreign_keys = ON")
+                db.row_factory = aiosqlite.Row
+                yield db
+        except sqlite3.Error as exc:
+            raise RuntimeError(f"Database error: {exc}") from exc
+
+    async def _create_tables(self) -> None:
+        async with aiosqlite.connect(self._db_path) as db:
+            await db.execute("PRAGMA foreign_keys = ON")
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS analysis (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    snapshot_id INTEGER NOT NULL,
+                    author TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    notes TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS analysis_items (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    analysis_id INTEGER NOT NULL,
+                    label TEXT NOT NULL,
+                    score INTEGER NOT NULL,
+                    payload TEXT,
+                    FOREIGN KEY(analysis_id) REFERENCES analysis(id) ON DELETE CASCADE
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_analysis_snapshot_id
+                ON analysis(snapshot_id)
+                """
+            )
+            await db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_analysis_created_at
+                ON analysis(created_at DESC)
+                """
+            )
+            await db.commit()
+
+    def _deserialize_payload(self, value: Optional[str]) -> Any:
+        if value is None:
+            return None
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+
+    def _build_item_record(self, row: aiosqlite.Row) -> AnalysisItemRecord:
+        return AnalysisItemRecord(
+            id=int(row["id"]),
+            analysis_id=int(row["analysis_id"]),
+            label=str(row["label"]),
+            score=int(row["score"]),
+            payload=self._deserialize_payload(row["payload"]),
+        )
+
+    def _build_analysis_record(
+        self, row: aiosqlite.Row, items: List[AnalysisItemRecord]
+    ) -> AnalysisRecord:
+        record = build_analysis(
+            analysis_id=int(row["id"]),
+            snapshot_id=int(row["snapshot_id"]),
+            author=str(row["author"]),
+            title=str(row["title"]),
+            notes=row["notes"],
+            created_at=datetime.fromisoformat(str(row["created_at"]))
+            if isinstance(row["created_at"], str)
+            else row["created_at"],
+        )
+        record.items.extend(items)
+        return record
+
+    async def _fetch_items(
+        self, db: aiosqlite.Connection, analysis_ids: List[int]
+    ) -> Dict[int, List[AnalysisItemRecord]]:
+        if not analysis_ids:
+            return {}
+        placeholders = ",".join("?" for _ in analysis_ids)
+        cursor = await db.execute(
+            f"""
+            SELECT id, analysis_id, label, score, payload
+            FROM analysis_items
+            WHERE analysis_id IN ({placeholders})
+            ORDER BY id ASC
+            """,
+            analysis_ids,
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        grouped: Dict[int, List[AnalysisItemRecord]] = {analysis_id: [] for analysis_id in analysis_ids}
+        for row in rows:
+            grouped.setdefault(int(row["analysis_id"]), []).append(self._build_item_record(row))
+        return grouped
+
+    async def _get_next_id(self, db: aiosqlite.Connection, table: str) -> int:
+        cursor = await db.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = ?", (table,)
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+        if row is None:
+            return 1
+        return int(row["seq"]) + 1
 
     async def create_analysis(
         self,
@@ -25,10 +161,54 @@ class AnalysisRepository:
         notes: Optional[str],
         items: Iterable[Dict[str, Any]],
     ) -> Dict[str, Any]:
+        await self._ensure_initialized()
         async with self._lock:
-            analysis_id = self._next_analysis_id
-            self._next_analysis_id += 1
             created_at = datetime.now(timezone.utc)
+            created_at_str = created_at.isoformat()
+            try:
+                async with self._connect() as db:
+                    cursor = await db.execute(
+                        """
+                        INSERT INTO analysis (snapshot_id, author, title, notes, created_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (snapshot_id, author, title, notes, created_at_str),
+                    )
+                    analysis_id = int(cursor.lastrowid)
+                    await cursor.close()
+
+                    item_records: List[AnalysisItemRecord] = []
+                    for item in items:
+                        payload = item.get("payload")
+                        payload_json = json.dumps(payload) if payload is not None else None
+                        cursor = await db.execute(
+                            """
+                            INSERT INTO analysis_items (analysis_id, label, score, payload)
+                            VALUES (?, ?, ?, ?)
+                            """,
+                            (
+                                analysis_id,
+                                item["label"],
+                                int(item["score"]),
+                                payload_json,
+                            ),
+                        )
+                        item_id = int(cursor.lastrowid)
+                        await cursor.close()
+                        item_records.append(
+                            AnalysisItemRecord(
+                                id=item_id,
+                                analysis_id=analysis_id,
+                                label=str(item["label"]),
+                                score=int(item["score"]),
+                                payload=payload,
+                            )
+                        )
+
+                    await db.commit()
+            except sqlite3.Error as exc:
+                raise RuntimeError(f"Database error: {exc}") from exc
+
             record = build_analysis(
                 analysis_id=analysis_id,
                 snapshot_id=snapshot_id,
@@ -37,74 +217,157 @@ class AnalysisRepository:
                 notes=notes,
                 created_at=created_at,
             )
-
-            for item in items:
-                item_id = self._next_item_id
-                self._next_item_id += 1
-                record.items.append(
-                    AnalysisItemRecord(
-                        id=item_id,
-                        analysis_id=analysis_id,
-                        label=item["label"],
-                        score=int(item["score"]),
-                        payload=item.get("payload") if isinstance(item.get("payload"), dict) else item.get("payload"),
-                    )
-                )
-
-            self._analysis[analysis_id] = record
+            record.items.extend(item_records)
             return record.serialize()
 
     async def get_analysis(self, analysis_id: int) -> Dict[str, Any]:
-        async with self._lock:
-            record = self._analysis.get(analysis_id)
-            if record is None:
+        await self._ensure_initialized()
+        async with self._connect() as db:
+            cursor = await db.execute(
+                """
+                SELECT id, snapshot_id, author, title, notes, created_at
+                FROM analysis
+                WHERE id = ?
+                """,
+                (analysis_id,),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+            if row is None:
                 raise KeyError(f"Analysis {analysis_id} not found")
+
+            items_map = await self._fetch_items(db, [int(row["id"])])
+            record = self._build_analysis_record(row, items_map.get(int(row["id"]), []))
             return record.serialize()
 
     async def list_analysis(self, snapshot_id: Optional[int] = None) -> List[Dict[str, Any]]:
-        async with self._lock:
-            records = list(self._analysis.values())
+        await self._ensure_initialized()
+        query = (
+            "SELECT id, snapshot_id, author, title, notes, created_at FROM analysis"
+        )
+        params: List[Any] = []
         if snapshot_id is not None:
-            records = [record for record in records if record.snapshot_id == snapshot_id]
-        records.sort(key=lambda record: (record.created_at, record.id), reverse=True)
-        return [record.serialize() for record in records]
+            query += " WHERE snapshot_id = ?"
+            params.append(snapshot_id)
+        query += " ORDER BY created_at DESC, id DESC"
+
+        async with self._connect() as db:
+            cursor = await db.execute(query, params)
+            rows = await cursor.fetchall()
+            await cursor.close()
+            analysis_ids = [int(row["id"]) for row in rows]
+            items_map = await self._fetch_items(db, analysis_ids)
+            records = [
+                self._build_analysis_record(row, items_map.get(int(row["id"]), []))
+                for row in rows
+            ]
+            return [record.serialize() for record in records]
 
     async def clear(self) -> None:
+        await self._ensure_initialized()
         async with self._lock:
-            self._analysis.clear()
-            self._next_analysis_id = 1
-            self._next_item_id = 1
+            async with self._connect() as db:
+                await db.execute("DELETE FROM analysis_items")
+                await db.execute("DELETE FROM analysis")
+                await db.execute(
+                    "DELETE FROM sqlite_sequence WHERE name IN ('analysis', 'analysis_items')"
+                )
+                await db.commit()
 
     async def export_state(self) -> Dict[str, Any]:
+        await self._ensure_initialized()
         async with self._lock:
-            return {
-                "next_analysis_id": self._next_analysis_id,
-                "next_item_id": self._next_item_id,
-                "analysis": [record.serialize() for record in self._analysis.values()],
-            }
+            async with self._connect() as db:
+                cursor = await db.execute(
+                    """
+                    SELECT id, snapshot_id, author, title, notes, created_at
+                    FROM analysis
+                    ORDER BY id ASC
+                    """
+                )
+                analysis_rows = await cursor.fetchall()
+                await cursor.close()
+                analysis_ids = [int(row["id"]) for row in analysis_rows]
+                items_map = await self._fetch_items(db, analysis_ids)
+
+                records = [
+                    self._build_analysis_record(row, items_map.get(int(row["id"]), []))
+                    for row in analysis_rows
+                ]
+
+                next_analysis_id = await self._get_next_id(db, "analysis")
+                next_item_id = await self._get_next_id(db, "analysis_items")
+
+                return {
+                    "next_analysis_id": next_analysis_id,
+                    "next_item_id": next_item_id,
+                    "analysis": [record.serialize() for record in records],
+                }
 
     async def import_state(self, state: Dict[str, Any]) -> None:
+        await self._ensure_initialized()
         async with self._lock:
-            self._analysis.clear()
-            self._next_analysis_id = int(state.get("next_analysis_id", 1))
-            self._next_item_id = int(state.get("next_item_id", 1))
-            for data in state.get("analysis", []):
-                record = AnalysisRecord(
-                    id=int(data["id"]),
-                    snapshot_id=int(data["snapshot_id"]),
-                    author=str(data["author"]),
-                    title=str(data["title"]),
-                    notes=data.get("notes"),
-                    created_at=datetime.fromisoformat(data["created_at"]),
+            async with self._connect() as db:
+                await db.execute("DELETE FROM analysis_items")
+                await db.execute("DELETE FROM analysis")
+                await db.execute(
+                    "DELETE FROM sqlite_sequence WHERE name IN ('analysis', 'analysis_items')"
                 )
-                for item in data.get("items", []):
-                    record.items.append(
-                        AnalysisItemRecord(
-                            id=int(item["id"]),
-                            analysis_id=int(item["analysis_id"]),
-                            label=str(item["label"]),
-                            score=int(item["score"]),
-                            payload=item.get("payload"),
-                        )
+
+                for data in state.get("analysis", []):
+                    created_at = data.get("created_at")
+                    if isinstance(created_at, str):
+                        created_at_str = created_at
+                    elif created_at is None:
+                        created_at_str = datetime.now(timezone.utc).isoformat()
+                    else:
+                        created_at_str = created_at.isoformat()
+                    await db.execute(
+                        """
+                        INSERT INTO analysis (id, snapshot_id, author, title, notes, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            int(data["id"]),
+                            int(data["snapshot_id"]),
+                            str(data["author"]),
+                            str(data["title"]),
+                            data.get("notes"),
+                            created_at_str,
+                        ),
                     )
-                self._analysis[record.id] = record
+                    for item in data.get("items", []):
+                        payload = item.get("payload")
+                        payload_json = json.dumps(payload) if payload is not None else None
+                        await db.execute(
+                            """
+                            INSERT INTO analysis_items (id, analysis_id, label, score, payload)
+                            VALUES (?, ?, ?, ?, ?)
+                            """,
+                            (
+                                int(item["id"]),
+                                int(item["analysis_id"]),
+                                str(item["label"]),
+                                int(item["score"]),
+                                payload_json,
+                            ),
+                        )
+
+                next_analysis_id = int(state.get("next_analysis_id", 1))
+                next_item_id = int(state.get("next_item_id", 1))
+
+                await db.execute(
+                    "DELETE FROM sqlite_sequence WHERE name IN ('analysis', 'analysis_items')"
+                )
+                if next_analysis_id > 1:
+                    await db.execute(
+                        "INSERT INTO sqlite_sequence(name, seq) VALUES ('analysis', ?)",
+                        (next_analysis_id - 1,),
+                    )
+                if next_item_id > 1:
+                    await db.execute(
+                        "INSERT INTO sqlite_sequence(name, seq) VALUES ('analysis_items', ?)",
+                        (next_item_id - 1,),
+                    )
+
+                await db.commit()

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -1,1 +1,3 @@
-# The backend currently runs purely on the Python standard library.
+aiohttp==3.9.1
+aiohttp-cors==0.7.0
+aiosqlite==0.19.0


### PR DESCRIPTION
## Summary
- refactor the analysis repository to use an async SQLite backend with schema creation, JSON serialization, and concurrency guards
- extend export/import helpers to operate on the database while preserving the existing API contract
- add the aiosqlite dependency required for the new persistence layer

## Testing
- pytest web/backend/tests *(fails: ModuleNotFoundError: No module named 'aiosqlite' because the environment cannot install new packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c0fdedec832c9ad2609b202793cc